### PR TITLE
[FIX] libfcgi.so location

### DIFF
--- a/library/server/libfcgi/libfcgi.ecf
+++ b/library/server/libfcgi/libfcgi.ecf
@@ -25,7 +25,7 @@
 				<platform value="windows"/>
 			</condition>
 		</external_library>
-		<external_library location="/usr/local/lib/libfcgi.so">
+		<external_library location="/usr/lib/libfcgi.so">
 			<condition>
 				<platform excluded_value="windows"/>
 			</condition>


### PR DESCRIPTION
On Ubuntu 10.04 LTS, libfcgi.so is in /usr/lib instead of /usr/local/lib
