### PR TITLE
use /usr/lib/libfcgi.so instead of /usr/local/lib/libfcgi.so

### DIFF
--- a/library/server/libfcgi/libfcgi-safe.ecf
+++ b/library/server/libfcgi/libfcgi-safe.ecf
@@ -25,7 +25,7 @@
 				<platform value="windows"/>
 			</condition>
 		</external_library>
-		<external_library location="/usr/local/lib/libfcgi.so">
+		<external_library location="/usr/lib/libfcgi.so">
 			<condition>
 				<platform excluded_value="windows"/>
 			</condition>


### PR DESCRIPTION
This was already fixed in libfcgi.ecf
(commit 65a998cec398905d7c9100e61cce5c39864796c6)
This fixes the libfcgi-safe.ecf file
