### PR TITLE
Use execution_variable instead of context

### DIFF
--- a/examples/filter/src/filter/authentication_filter.e
+++ b/examples/filter/src/filter/authentication_filter.e
@@ -8,9 +8,9 @@ class
 	AUTHENTICATION_FILTER
 
 inherit
-	WSF_FILTER_CONTEXT_HANDLER [FILTER_HANDLER_CONTEXT]
+	WSF_FILTER
 
-	WSF_URI_TEMPLATE_CONTEXT_HANDLER [FILTER_HANDLER_CONTEXT]
+	WSF_URI_TEMPLATE_HANDLER
 
 	SHARED_DATABASE_API
 
@@ -18,7 +18,7 @@ inherit
 
 feature -- Basic operations
 
-	execute (ctx: FILTER_HANDLER_CONTEXT; req: WSF_REQUEST; res: WSF_RESPONSE)
+	execute (req: WSF_REQUEST; res: WSF_RESPONSE)
 			-- Execute the filter
 		local
 			l_auth: HTTP_AUTHORIZATION
@@ -31,8 +31,8 @@ feature -- Basic operations
 				attached l_auth.password as l_auth_password and then
 				l_auth_password.same_string (l_user.password)
 			then
-				ctx.set_user (l_user)
-				execute_next (ctx, req, res)
+				req.set_execution_variable ("user", l_user)
+				execute_next (req, res)
 			else
 				handle_unauthorized ("Unauthorized", req, res)
 			end
@@ -56,6 +56,6 @@ feature {NONE} -- Implementation
 		end
 
 note
-	copyright: "2011-2012, Olivier Ligot, Jocelyn Fiat and others"
+	copyright: "2011-2013, Olivier Ligot, Jocelyn Fiat and others"
 	license: "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 end

--- a/examples/filter/src/filter_server.e
+++ b/examples/filter/src/filter_server.e
@@ -34,18 +34,17 @@ feature {NONE} -- Initialization
 	create_filter
 			-- Create `filter'
 		local
-			l_router: WSF_ROUTER
 			l_authentication_filter_hdl: AUTHENTICATION_FILTER
 			l_user_filter: USER_HANDLER
 			l_routing_filter: WSF_ROUTING_FILTER
 		do
-			create l_router.make (1)
+			create router.make (1)
 			create l_authentication_filter_hdl
 			create l_user_filter
 			l_authentication_filter_hdl.set_next (l_user_filter)
 
-			l_router.handle_with_request_methods ("/user/{userid}", l_authentication_filter_hdl, l_router.methods_get)
-			create l_routing_filter.make (l_router)
+			router.handle_with_request_methods ("/user/{userid}", l_authentication_filter_hdl, router.methods_get)
+			create l_routing_filter.make (router)
 			l_routing_filter.set_execute_default_action (agent execute_default)
 			filter := l_routing_filter
 		end
@@ -73,30 +72,21 @@ feature -- Basic operations
 		end
 
 	execute_default (req: WSF_REQUEST; res: WSF_RESPONSE)
-			-- I'm using this method to handle the method not allowed response
-			-- in the case that the given uri does not have a corresponding http method
-			-- to handle it.
 		local
-			h : HTTP_HEADER
-			l_description : STRING
-			l_api_doc : STRING
+			l_message: WSF_DEFAULT_ROUTER_RESPONSE
 		do
-			if req.content_length_value > 0 then
-				req.input.read_string (req.content_length_value.as_integer_32)
-			end
-			create h.make
-			h.put_content_type_text_plain
-			l_api_doc := "%NPlease check the API%NURI:/user/{userid} METHOD: GET%N"
-			l_description := req.request_method + req.request_uri + " is not allowed" + "%N" + l_api_doc
-			h.put_content_length (l_description.count)
-			h.put_current_date
-			res.set_status_code ({HTTP_STATUS_CODE}.method_not_allowed)
-			res.put_header_text (h.string)
-			res.put_string (l_description)
+			create l_message.make_with_router (req, router)
+			l_message.set_documentation_included (True)
+			res.send (l_message)
 		end
 
+feature {NONE} -- Implementation
+
+	router: WSF_ROUTER;
+			-- Router
+
 note
-	copyright: "2011-2012, Olivier Ligot, Jocelyn Fiat and others"
+	copyright: "2011-2013, Olivier Ligot, Jocelyn Fiat and others"
 	license: "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/examples/filter/src/resource/user_handler.e
+++ b/examples/filter/src/resource/user_handler.e
@@ -8,11 +8,11 @@ class
 	USER_HANDLER
 
 inherit
-	WSF_FILTER_CONTEXT_HANDLER [FILTER_HANDLER_CONTEXT]
+	WSF_FILTER
 
-	WSF_URI_TEMPLATE_CONTEXT_HANDLER [FILTER_HANDLER_CONTEXT]
+	WSF_URI_TEMPLATE_HANDLER
 
-	WSF_RESOURCE_CONTEXT_HANDLER_HELPER [FILTER_HANDLER_CONTEXT]
+	WSF_RESOURCE_HANDLER_HELPER
 		redefine
 			do_get
 		end
@@ -23,30 +23,30 @@ inherit
 
 feature -- Basic operations
 
-	execute (ctx: FILTER_HANDLER_CONTEXT; req: WSF_REQUEST; res: WSF_RESPONSE)
+	execute (req: WSF_REQUEST; res: WSF_RESPONSE)
 			-- Execute request handler	
 		do
-			execute_methods (ctx, req, res)
-			execute_next (ctx, req, res)
+			execute_methods (req, res)
+			execute_next (req, res)
 		end
 
-	do_get (ctx: FILTER_HANDLER_CONTEXT; req: WSF_REQUEST; res: WSF_RESPONSE)
+	do_get (req: WSF_REQUEST; res: WSF_RESPONSE)
 			-- Using GET to retrieve resource information.
 			-- If the GET request is SUCCESS, we response with
 			-- 200 OK, and a representation of the user
 			-- If the GET request is not SUCCESS, we response with
 			-- 404 Resource not found
 		require else
-			authenticated_user_attached: attached ctx.user
+			authenticated_user_attached: attached {USER} req.execution_variable ("user")
 		local
 			id :  STRING
 		do
 			if attached req.orig_path_info as orig_path then
 				id := get_user_id_from_path (orig_path)
 				if attached retrieve_user (id) as l_user then
-					if l_user ~ ctx.user then
+					if l_user ~ req.execution_variable ("user") then
 						compute_response_get (req, res, l_user)
-					elseif attached ctx.user as l_auth_user then
+					elseif attached {USER} req.execution_variable ("user") as l_auth_user then
 						-- Trying to access another user that the authenticated one,
 						-- which is forbidden in this example...
 						handle_forbidden ("You try to access the user " + id.out + " while authenticating with the user " + l_auth_user.id.out, req, res)
@@ -92,6 +92,6 @@ feature {NONE} -- Implementation
 		end
 
 note
-	copyright: "2011-2012, Olivier Ligot, Jocelyn Fiat and others"
+	copyright: "2011-2013, Olivier Ligot, Jocelyn Fiat and others"
 	license: "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 end


### PR DESCRIPTION
This is mainly to be compatibe with other classes API.

In a lot of classes, we define methods like this:

``` Eiffel
 method (req: WSF_REQUEST; res: WSF_RESPONSE)
    do
        ...
    end
```

With the context, the signature becomes:

``` Eiffel
 method (ctx: C; req: WSF_REQUEST; res: WSF_RESPONSE)
    do
        ...
    end
```

So, I can't build a filter chain where one filter is with context
and one is without context (I can't call
WSF_FILTER.set_next (a_next: WSF_FILTER) with a filter that is a
descendant of WSF_CONTEXT_HANDLER).

Moreover, having to play with generic types just to pass some
data from one filter to another is a bit overkill imho.
Because this is really what I use contexts for:
to pass data from one filter to the next one.

Regarding execution_variable and strong typing, if we want to achieve these,
I realize we could write a class with one getter and one setter like this:

``` Eiffel
  class
    TYPED_DATA

  feature -- Access

  user (req: WSF_REQUEST): detachable USER
    do
        if attached {USER} req.execution_variable ("user") as l_user then
            Result := l_user
        end
    end

  feature -- Element change

  set_user (req: WSF_REQUEST; a_user: USER)
    do
        req.set_execution_variable ("user", a_user)
    end
```

Now, I realize this is a major change since the last time we talked about this,
but at the end, after having played with both, I prefer the one with
execution_variable.
