### PR TITLE
Added automatic options result

### DIFF
--- a/library/server/wsf/router/wsf_router.e
+++ b/library/server/wsf/router/wsf_router.e
@@ -158,13 +158,19 @@ feature {NONE} -- Dispatch implementation
 		local
 			l_req_method: READABLE_STRING_8
 			head_res: WSF_HEAD_RESPONSE_WRAPPER
+			l_cors: WSF_CORS_OPTIONS_RESPONSE
 		do
 			l_req_method := request_method (req)
 			router_dispatch_for_request_method (req, res, sess, l_req_method)
-			if not sess.dispatched and l_req_method = {HTTP_REQUEST_METHODS}.method_head then
-				create head_res.make_from_response (res)
-				req.set_request_method ({HTTP_REQUEST_METHODS}.method_GET)
-				router_dispatch_for_request_method (req, head_res, sess, {HTTP_REQUEST_METHODS}.method_GET)
+			if not sess.dispatched then
+				if l_req_method = {HTTP_REQUEST_METHODS}.method_options and allowed_methods_for_request (req).has_method_options then
+					create l_cors.make (req, Current)
+					res.send (l_cors)
+				elseif l_req_method = {HTTP_REQUEST_METHODS}.method_head and allowed_methods_for_request (req).has_method_head then
+					create head_res.make_from_response (res)
+					req.set_request_method ({HTTP_REQUEST_METHODS}.method_GET)
+					router_dispatch_for_request_method (req, head_res, sess, {HTTP_REQUEST_METHODS}.method_GET)
+				end
 			end
 		end
 


### PR DESCRIPTION
Also checked that OPTIONS/HEAD method is actually allowed.

The user should have the option to disallow these (although we might want to make it that the user must specifically call disable_head/disable_options, so as to take more advantage of the default automatic response).

Having written the above, I note that the activity diagram that you included in documentation, shows 405 method not allowed response not being generated for GET or HEAD (and OPTIONS automatically gets a 200 OK response). So it would seem entirely reasonable that we DON'T allow the user to disable these responses (just as the code is doing now). However:

1) How do we enforce support for GET? (i.e. if there is a mapping for PUT, POST or DELETE, there is also one for GET?)
2) I can't find any support in the specification for this restriction on the 405 response.

So I'm inclined to think the logic is fine just as it is.
