### PR TITLE
Use port number 9090 instead of 80

### DIFF
--- a/examples/simple/application.e
+++ b/examples/simple/application.e
@@ -8,11 +8,22 @@ class
 
 inherit
 	WSF_DEFAULT_SERVICE
+		redefine
+			initialize
+		end
 
 create
 	make_and_launch
 
 feature {NONE} -- Initialization
+
+	initialize
+			-- Initialize current service.
+		do
+			set_service_option ("port", 9090)
+		end
+
+feature -- Basic operations
 
 	execute (req: WSF_REQUEST; res: WSF_RESPONSE)
 		do


### PR DESCRIPTION
Port 80 is often already used by standard webservers (Apache, nginx, ...).
Moreover, on Linux, ports below 1024 can only be opened by root.
