### PR TITLE
Remove invariant violation.

### DIFF
--- a/library/server/wsf/src/wsf_request.e
+++ b/library/server/wsf/src/wsf_request.e
@@ -1,18 +1,18 @@
 note
 	description: "[
 			Server request context of the httpd request
-			
+
 			It includes CGI interface and a few extra values that are usually valuable
-			    meta_variable (a_name: READABLE_STRING_GENERAL): detachable WSF_STRING
-			    meta_string_variable (a_name: READABLE_STRING_GENERAL): detachable READABLE_STRING_32
-			    
+				 meta_variable (a_name: READABLE_STRING_GENERAL): detachable WSF_STRING
+				 meta_string_variable (a_name: READABLE_STRING_GENERAL): detachable READABLE_STRING_32
+
 			In addition it provides
-				
+
 				query_parameter (a_name: READABLE_STRING_GENERAL): detachable WSF_VALUE
 				form_parameter (a_name: READABLE_STRING_GENERAL): detachable WSF_VALUE
 				cookie (a_name: READABLE_STRING_GENERAL): detachable WSF_VALUE
 				...
-				
+
 			And also has
 				execution_variable (a_name: READABLE_STRING_GENERAL): detachable ANY
 					--| to keep value attached to the request
@@ -140,7 +140,6 @@ feature -- Destroy
 			end
 
 			content_length_value := 0
-			content_type := Void
 			execution_variables_table.wipe_out
 			internal_cookies_table := Void
 			internal_form_data_parameters_table := Void
@@ -208,7 +207,7 @@ feature -- Error handling
 
 	error_handler: ERROR_HANDLER
 			-- Error handler
-			-- By default initialized to new handler	
+			-- By default initialized to new handler
 
 feature -- Access: Input
 
@@ -219,7 +218,7 @@ feature -- Access: Input
 		end
 
 	is_chunked_input: BOOLEAN
-			-- Is request using chunked transfer-encoding?	
+			-- Is request using chunked transfer-encoding?
 			-- If True, the Content-Length has no meaning
 		do
 			Result := wgi_request.is_chunked_input
@@ -375,7 +374,7 @@ feature -- Eiffel WGI access
 			Result := wgi_request.wgi_connector
 		end
 
-feature {WSF_REQUEST_EXPORTER} -- Override value		
+feature {WSF_REQUEST_EXPORTER} -- Override value
 
 	set_request_method (a_request_method: like request_method)
 			-- Set `request_method' to `a_request_method'
@@ -414,7 +413,7 @@ feature {NONE} -- Access: global variable
 			end
 		end
 
-feature -- Access: global variables	
+feature -- Access: global variables
 
 	items: ITERABLE [WSF_VALUE]
 		do
@@ -654,9 +653,9 @@ feature -- Access: CGI Meta variables
 feature {NONE} -- Access: CGI meta parameters
 
 	meta_variables_table: STRING_TABLE [WSF_STRING]
-			-- CGI Environment parameters		
+			-- CGI Environment parameters
 
-feature -- Access: CGI meta parameters - 1.1			
+feature -- Access: CGI meta parameters - 1.1
 
 	auth_type: detachable READABLE_STRING_8
 			-- This variable is specific to requests made via the "http"
@@ -1128,7 +1127,7 @@ feature -- HTTP_*
 
 	http_access_control_request_headers: detachable READABLE_STRING_8
 			-- Indicates which headers will be used in the actual request
-                        -- as part of the preflight request
+								-- as part of the preflight request
 		do
 			Result := wgi_request.http_access_control_request_headers
 		end
@@ -1319,7 +1318,7 @@ feature -- Query parameters
 feature {NONE} -- Query parameters: implementation
 
 	query_parameters_table: STRING_TABLE [WSF_VALUE]
-			-- Parameters extracted from QUERY_STRING	
+			-- Parameters extracted from QUERY_STRING
 		local
 			vars: like internal_query_parameters_table
 			p,e: INTEGER
@@ -1496,7 +1495,7 @@ feature {NONE} -- Form fields and related
 	uploaded_files_table: STRING_TABLE [WSF_UPLOADED_FILE]
 
 	get_form_parameters
-			-- Variables sent by POST, ... request	
+			-- Variables sent by POST, ... request
 		local
 			vars: like internal_form_data_parameters_table
 			l_raw_data_cell: detachable CELL [detachable STRING_8]
@@ -1528,7 +1527,7 @@ feature {NONE} -- Form fields and related
 		end
 
 	form_parameters_table: STRING_TABLE [WSF_VALUE]
-			-- Variables sent by POST request	
+			-- Variables sent by POST request
 		local
 			vars: like internal_form_data_parameters_table
 		do
@@ -1541,7 +1540,7 @@ feature {NONE} -- Form fields and related
 			Result := vars
 		end
 
-feature {NONE} -- Implementation: smart parameter identification		
+feature {NONE} -- Implementation: smart parameter identification
 
 	add_value_to_table (a_name: READABLE_STRING_8; a_value: READABLE_STRING_8; a_table: STRING_TABLE [WSF_VALUE])
 			-- Add urlencoded parameter  `a_name'=`a_value' to `a_table'
@@ -1749,7 +1748,7 @@ feature {NONE} -- Implementation: URL Utility
 			-- Server url
 
 	internal_url_base: detachable STRING
-			-- URL base of potential script	
+			-- URL base of potential script
 
 feature -- Element change
 
@@ -1909,7 +1908,7 @@ feature {NONE} -- Implementation
 			end
 		end
 
-feature {NONE} -- Implementation: utilities	
+feature {NONE} -- Implementation: utilities
 
 	single_slash_starting_string (s: READABLE_STRING_32): STRING_32
 			-- Return the string `s' (or twin) with one and only one starting slash
@@ -1939,7 +1938,7 @@ feature {NONE} -- Implementation: utilities
 					check i >= 2 and i <= n end
 					Result := s.substring (i - 1, s.count)
 				else
-					--| starts with one '/' and only one		
+					--| starts with one '/' and only one
 					Result := s
 				end
 			elseif n = 1 then


### PR DESCRIPTION
The destroy did set content_type to Void, potentially violating the invariant:

  wgi_request.content_type /= Void implies content_type /= Void

Have removed setting this to void.
