### PR TITLE
Updated set_value for WSF_FORM_SELECTABLE_INPUT (for example a checkb…

### DIFF
--- a/library/server/wsf_html/form/wsf_form_selectable_input.e
+++ b/library/server/wsf_html/form/wsf_form_selectable_input.e
@@ -72,12 +72,22 @@ feature -- Change
 
 	set_value (v: detachable WSF_VALUE)
 			-- Set value `v' if applicable to Current
+		local
+			l_found: BOOLEAN
 		do
 			if attached {ITERABLE [WSF_VALUE]} v as lst then
 				across
 					lst as c
+				until
+					l_found
 				loop
-					set_checked_by_value (c.item)
+					if attached {WSF_STRING} c.item as s and then is_same_value (s.value) then
+						set_checked_by_value (c.item)
+						l_found := true
+					end
+				end
+				if not l_found then
+					set_checked (False)
 				end
 			else
 				set_checked_by_value (v)


### PR DESCRIPTION
…ox).

Call the feature set_checked_by_value iff the the current value exist in the
list of values, in other case set checked in Flase.
If we call set_checked_by_value without filter, previous checked values will be
set in False.