### PR TITLE
Updated HTTP_COOKIE implementation, by default now the Cookie will no…

### DIFF
--- a/library/network/protocol/http/src/http_cookie.e
+++ b/library/network/protocol/http/src/http_cookie.e
@@ -110,6 +110,50 @@ feature -- Access
 			Result := not d.has_error and then d.rfc1123_string.same_string (a_string)
 		end
 
+
+	include_max_age: BOOLEAN
+		obsolete
+			"Use max_age directly, included if its > 0 "
+		do
+			Result := max_age > 0
+		end
+
+	include_expires: BOOLEAN
+		obsolete
+			"Use expires directy, included if it's /= Void"
+		do
+			Result := expiration /= Void
+		end
+
+	mark_max_age
+ 			-- Set `max_age > 0'
+ 			-- Set `expires to void'
+ 			-- Set-Cookie will include only Max-Age attribute and not Expires.
+  		obsolete
+  			"Uset set_max_age and unset_ features to add or remove the attributes in the response header"
+  		do
+ 			max_age := 1
+ 			expiration := Void
+  		ensure
+ 			max_age_true: include_max_age
+ 			expire_false: not include_expires
+  		end
+
+
+  		mark_expires
+ 			-- Set `mark_age' to -1.
+ 			-- Set `expiration to a default date'
+  			-- Set-Cookie will include only Expires attribute and not Max_Age.
+  		obsolete
+  			"Use set_expiration and unset_ features to add or remove the attribute in the response header"
+  		do
+ 			max_age := -1
+ 			set_expiration_date (create {DATE_TIME}.make_now_utc)
+  		ensure
+ 			expires_true: include_expires
+ 			max_age_false: not include_max_age
+  		end
+
 feature -- Change Element
 
 	set_name (a_name: READABLE_STRING_8)

--- a/library/network/protocol/http/src/http_cookie.e
+++ b/library/network/protocol/http/src/http_cookie.e
@@ -229,10 +229,23 @@ feature -- Change Element
 			max_age_false: not include_max_age
 		end
 
+	mark_expires_and_max_age
+			-- Set `include_expires' to True.
+			-- Set `include_max_age' to True
+	 		-- Set-Cookie will include both Max-Age, Expires attributes.
+		do
+			include_expires := True
+			include_max_age := True
+		ensure
+			expires_false: include_expires
+			max_age_false: include_max_age
+		end
+
 	set_default_expires_max_age
 			-- Set `include_expires' to False.
 			-- Set `include_max_age' to False
-	 		-- Set-Cookie will include both Max-Age, Expires attributes.
+	 		-- Set-Cookie will not include Max-Age, Expires attributes.
+	 		-- The user agent will retain the cookie until "the current session is over".
 		do
 			include_expires := False
 			include_max_age := False
@@ -270,8 +283,19 @@ feature -- Output
 				s.append ("; Path=")
 				s.append (l_path)
 			end
-				-- Expire
-			if include_expires then
+
+				-- Expires and Max Age	
+			if include_expires and then include_max_age then
+					-- Expire
+				if attached expiration as l_expires then
+					s.append ("; Expires=")
+					s.append (l_expires)
+				end
+					-- Max age
+				s.append ("; Max-Age=")
+				s.append_integer (max_age)
+				--	Expires
+			elseif include_expires then
 				if attached expiration as l_expires then
 					s.append ("; Expires=")
 					s.append (l_expires)
@@ -284,16 +308,10 @@ feature -- Output
 				-- Default
 				check
 						-- By default the attributes include_expires and include_max_age are False.
-						-- Meaning that Expires and Max-Age headers are included in the response.
+						-- Meaning that Expires and Max-Age headers are not included in the response.
+						-- Set the cookie as a Session Cookie.
 					default: (not include_expires) and (not include_max_age)
 				end
-				if attached expiration as l_expires then
-					s.append ("; Expires=")
-					s.append (l_expires)
-				end
-
-				s.append ("; Max-Age=")
-				s.append_integer (max_age)
 			end
 
 			if secure then
@@ -339,7 +357,7 @@ feature {NONE} -- Constants
 		end
 
 note
-	copyright: "2011-2015, Jocelyn Fiat, Eiffel Software and others"
+	copyright: "2011-2016, Jocelyn Fiat, Eiffel Software and others"
 	license: "Eiffel Forum License v2 (see http://www.eiffel.com/licensing/forum.txt)"
 	source: "[
 			Eiffel Software

--- a/library/network/protocol/http/tests/http_cookie_test_set.e
+++ b/library/network/protocol/http/tests/http_cookie_test_set.e
@@ -50,13 +50,13 @@ feature -- Test routines
 			l_cookie: HTTP_COOKIE
 		do
 			create l_cookie.make ("user_id", "u12345")
-			l_cookie.mark_expires_and_max_age
 			l_cookie.set_domain ("www.example.com")
 			l_cookie.set_expiration ("Sat, 18 Apr 2015 21:22:05 GMT")
 			l_cookie.set_path ("/")
 			l_cookie.set_secure (True)
 			l_cookie.set_http_only (True)
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com; Path=/; Expires=Sat, 18 Apr 2015 21:22:05 GMT; Max-Age=-1; Secure; HttpOnly"))
+			l_cookie.set_max_age (1)
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com; Path=/; Expires=Sat, 18 Apr 2015 21:22:05 GMT; Max-Age=1; Secure; HttpOnly"))
 		end
 
 	test_cookie_include_expires
@@ -69,7 +69,6 @@ feature -- Test routines
 			l_cookie.set_path ("/")
 			l_cookie.set_secure (True)
 			l_cookie.set_http_only (True)
-			l_cookie.mark_expires
 			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com; Path=/; Expires=Sat, 18 Apr 2015 21:22:05 GMT; Secure; HttpOnly"))
 		end
 
@@ -83,8 +82,8 @@ feature -- Test routines
 			l_cookie.set_path ("/")
 			l_cookie.set_secure (True)
 			l_cookie.set_http_only (True)
-			l_cookie.mark_max_age
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com; Path=/; Max-Age=-1; Secure; HttpOnly"))
+			l_cookie.set_max_age (1)
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com; Path=/; Expires=Sat, 18 Apr 2015 21:22:05 GMT; Max-Age=1; Secure; HttpOnly"))
 		end
 
 	test_cookie_defaults_and_http_only
@@ -130,7 +129,6 @@ feature -- Test routines
 			l_cookie: HTTP_COOKIE
 		do
 			create l_cookie.make ("user_id", "u12345")
-			l_cookie.mark_max_age
 			l_cookie.set_max_age (120)
 			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Max-Age=120"))
 		end

--- a/library/network/protocol/http/tests/http_cookie_test_set.e
+++ b/library/network/protocol/http/tests/http_cookie_test_set.e
@@ -20,7 +20,7 @@ feature -- Test routines
 			l_cookie: HTTP_COOKIE
 		do
 			create l_cookie.make ("user_id", "u12345")
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Max-Age=-1"))
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345"))
 		end
 
 	test_cookie_value_with_illegal_characters
@@ -42,7 +42,7 @@ feature -- Test routines
 			l_cookie: HTTP_COOKIE
 		do
 			create l_cookie.make ("user_id", "")
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=; Max-Age=-1"))
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id="))
 		end
 
 	test_cookie_full_attributes
@@ -50,6 +50,7 @@ feature -- Test routines
 			l_cookie: HTTP_COOKIE
 		do
 			create l_cookie.make ("user_id", "u12345")
+			l_cookie.mark_expires_and_max_age
 			l_cookie.set_domain ("www.example.com")
 			l_cookie.set_expiration ("Sat, 18 Apr 2015 21:22:05 GMT")
 			l_cookie.set_path ("/")
@@ -92,7 +93,7 @@ feature -- Test routines
 		do
 			create l_cookie.make ("user_id", "u12345")
 			l_cookie.set_http_only (True)
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Max-Age=-1; HttpOnly"))
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; HttpOnly"))
 		end
 
 	test_cookie_defaults_and_secure
@@ -101,7 +102,7 @@ feature -- Test routines
 		do
 			create l_cookie.make ("user_id", "u12345")
 			l_cookie.set_secure (True)
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Max-Age=-1; Secure"))
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Secure"))
 		end
 
 
@@ -111,7 +112,7 @@ feature -- Test routines
 		do
 			create l_cookie.make ("user_id", "u12345")
 			l_cookie.set_domain ("www.example.com")
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com; Max-Age=-1"))
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com"))
 		end
 
 
@@ -121,7 +122,7 @@ feature -- Test routines
 		do
 			create l_cookie.make ("user_id", "u12345")
 			l_cookie.set_path ("/")
-			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Path=/; Max-Age=-1"))
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Path=/"))
 		end
 
 	test_cookie_default_and_custom_max_age
@@ -129,6 +130,7 @@ feature -- Test routines
 			l_cookie: HTTP_COOKIE
 		do
 			create l_cookie.make ("user_id", "u12345")
+			l_cookie.mark_max_age
 			l_cookie.set_max_age (120)
 			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Max-Age=120"))
 		end
@@ -147,6 +149,18 @@ feature -- Test routines
 		do
 			create l_cookie.make ("user_id", "u12345")
 			assert ("Invalid RFC1123", not l_cookie.is_valid_rfc1123_date ("Thuesday, 19 Mar 2015 16:14:03 GMT"))
+		end
+
+	test_cookie_without_max_age_and_expires
+		local
+			l_cookie: HTTP_COOKIE
+		do
+			create l_cookie.make ("user_id", "u12345")
+			l_cookie.set_domain ("www.example.com")
+			l_cookie.set_path ("/")
+			l_cookie.set_secure (True)
+			l_cookie.set_http_only (True)
+			assert("Expected", l_cookie.header_line.same_string ("Set-Cookie: user_id=u12345; Domain=www.example.com; Path=/; Secure; HttpOnly"))
 		end
 
 


### PR DESCRIPTION
…t set

max-age and expires, so it will define a Session Cookie.

Added a new feature mark_expires_and_max_age, to send both attribues in a
response, in this case max_age takes precendence over expires.

Updated test cases.